### PR TITLE
Fixed catapult-data.json file corruption when deleting a connection

### DIFF
--- a/src-tauri/src/con.rs
+++ b/src-tauri/src/con.rs
@@ -191,7 +191,7 @@ impl ConnectionStore {
     fn write_connections_to_disk(&self) -> Result<(), Error> {
         let c = self.cache.lock().unwrap();
         let val = serde_json::to_string_pretty(c.deref())?;
-        let mut f = OpenOptions::new().append(false).create(true).write(true).open(&self.con_location);
+        let mut f = OpenOptions::new().append(false).create(true).write(true).truncate(true).open(&self.con_location);
         if let Err(e) = f {
             println!("unable to open file for writing: {}", e.to_string());
             return Err(Error::new(e));


### PR DESCRIPTION
This fixes the second half of issue #4, where the `catapult-data.json` file is corrupted when deleting a connection.