### PR TITLE
Updated README for Windows. Made the app work in Windows by using cor…

### DIFF
--- a/.github/workflows/build-catapault.yml
+++ b/.github/workflows/build-catapault.yml
@@ -1,0 +1,73 @@
+name: Build on every push and every pull-request
+on:
+  pull_request:
+    paths-ignore:
+      - '*.md'
+  push:
+    paths-ignore:
+      - '*.md'
+  workflow_dispatch:
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        platform: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies (ubuntu only)
+        if: startsWith(matrix.platform, 'ubuntu')
+        # You can remove libayatana-appindicator3-dev if you don't use the system tray feature.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev
+
+      - name: Rust setup
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+
+      - name: Sync node version and setup cache
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+          cache: 'npm' # Set this to npm, yarn or pnpm.
+
+      - name: Install frontend dependencies
+        # If you don't have `beforeBuildCommand` configured you may want to build your frontend here too.
+        run: npm install # Change this to npm, yarn or pnpm.
+
+      - name: Build the app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ github.ref_name }} # This only works if your workflow triggers on new tags.
+          releaseName: 'App Name v__VERSION__' # tauri-action replaces \_\_VERSION\_\_ with the app version.
+          releaseBody: 'See the assets to download and install this version.'
+          releaseDraft: true
+          prerelease: false
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ matrix.platform }}
+          path: |
+            src-tauri/target/release/bundle/nsis/*.exe
+            src-tauri/target/release/bundle/msi/*.msi
+            src-tauri/target/release/bundle/appimage/*.AppImage
+            src-tauri/target/release/bundle/deb/*.deb
+            src-tauri/target/release/bundle/rpm/*.rpm
+            src-tauri/target/release/bundle/dmg/*.dmg
+            src-tauri/target/release/bundle/macos/*.app

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ These compilation instructions are written for users not familiar with Rust and 
 
 You should generally follow the Tauri Getting started guide: https://tauri.app/v1/guides/getting-started/prerequisites
 
+A good reference for how to run builds is the file .github/workflows/build-catapault.yml . If you can replicate the same steps the build pipeline does, then you should have good builds!
+
 ### MacOS
 
 1. Open the project in VS Code. Let VS code install the suggested plugins.
@@ -29,4 +31,15 @@ Should be very similar to MacOS.
 
 ### Windows 
 
-Please make a PR if you use Windows and know how to compile the app
+Please make a PR if you use Windows and know how to compile the app!
+
+___Follow the instructions at___: https://tauri.app/v1/guides/getting-started/prerequisites/#setting-up-windows
+
+Follow the openssl instructions at: https://docs.rs/crate/openssl/0.9.24 *EXCEPT* you have to use different commands to set env vars in PowerShell:
+```
+$env:OPENSSL_DIR='C:\Program Files\OpenSSL-Win64\'
+$env:OPENSSL_INCLUDE_DIR='C:\Program Files\OpenSSL-Win64\include'
+$env:OPENSSL_LIB_DIR='C:\Program Files\OpenSSL-Win64\lib'
+$env:OPENSSL_NO_VENDOR=1
+Get-ChildItem Env
+```


### PR DESCRIPTION
…rect classpath separators. Introduced github actions to build on every push and every PR.

The only change that was needed to make this work in Windows was to change the classpath separator from `;` to `:`. It is different in Java for Windows than for other OSes.

I updated the README. I believe it is accurate but it may contain extra steps. I would love to see corrections for a tighter process. This was tedious to set up in Windows.

Finally, I added a Github action that:

* runs on every push 
* runs on every PR
* builds for MacOS, Ubuntu, and Windows
* makes the build files available as archives for download from the Action

This action lets users or testers bet a build on every change.